### PR TITLE
Pass args to expectTypeOf

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,7 @@ const isAuthed = trpc.newContext((params) => {
 export const appRouter = trpc.router({
   queries: {
     'post.all': (params) => {
-      expectTypeOf<typeof params>().toMatchTypeOf<{
+      expectTypeOf(params).toMatchTypeOf<{
         ctx: Context;
       }>();
       return {
@@ -58,10 +58,8 @@ export const appRouter = trpc.router({
         }),
       ),
       (params) => {
-        type TContext = typeof params.ctx;
-        type TInput = typeof params.input;
-        expectTypeOf<TContext>().toMatchTypeOf<{ user?: { id: string } }>();
-        expectTypeOf<TInput>().toMatchTypeOf<{
+        expectTypeOf(params.ctx).toMatchTypeOf<{ user?: { id: string } }>();
+        expectTypeOf(params.input).toMatchTypeOf<{
           hello: string;
           lengthOf: number;
         }>();


### PR DESCRIPTION
Not important, just thought I’d mention that you can actually pass a variable to expectTypeOf rather than using <typeof whatever> and a PR is as easy a way as any to communicate that!

note: not sure if you tried this and it doesn’t work or something- if so it’s a bug in expect-type