### PR TITLE
make `createRouter()` stricter

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -63,8 +63,14 @@ async function main() {
     // no leaky
     const trpc = initTRPC();
     trpc.router({
-      queries: {},
-      // @ts-expect-error should not exist
+      queries: {
+        test: () => {
+          return {
+            data: 'ok',
+          };
+        },
+      },
+      // @ts-expect-error should error
       doesNotExist: {},
     });
   }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
 import { appRouter } from './server';
-import { inferProcedure } from './trpc/server';
+import { inferProcedure, initTRPC } from './trpc/server';
 
 ///////////// this below are just tests that the type checking is doing it's thing right ////////////
 async function main() {
@@ -58,6 +58,15 @@ async function main() {
       hello: string;
       lengthOf: number;
     }>();
+  }
+  {
+    // no leaky
+    const trpc = initTRPC();
+    trpc.router({
+      queries: {},
+      // @ts-expect-error should not exist
+      doesNotExist: {},
+    });
   }
 }
 main();

--- a/src/trpc/server/router.ts
+++ b/src/trpc/server/router.ts
@@ -10,10 +10,17 @@ export interface ProceduresByType<TContext> {
   mutations?: ProcedureRecord<TContext>;
 }
 
+type ValidateShape<TActualShape, TExpectedShape> =
+  TActualShape extends TExpectedShape
+    ? Exclude<keyof TActualShape, keyof TExpectedShape> extends never
+      ? TActualShape
+      : TExpectedShape
+    : never;
+
 export function createRouterWithContext<TContext>() {
   return function createRouter<TProcedures extends ProceduresByType<TContext>>(
-    procedures: TProcedures,
+    procedures: ValidateShape<TProcedures, ProceduresByType<TContext>>,
   ): TProcedures {
-    return procedures;
+    return procedures as any;
   };
 }


### PR DESCRIPTION
- Ensure no extra params are sent to `createRouter()`
- Maybe this slows down TypeScript performance?