### PR TITLE
[RFC] Error callback and no more `return { data: X }`

### DIFF
--- a/.big/client.ts
+++ b/.big/client.ts
@@ -6,11 +6,13 @@ const client = createClient<typeof appRouter>();
 const { queries } = createRouterProxy<typeof appRouter>();
 
 async function main() {
-  const q1 = await client.query(queries.r99q5, { hello: 'world' });
-  // const q1 = await client.query('r99q5', { hello: 'world' });
+  const q1 = await client.query(queries.r29q5, { hello: 'world' });
+  // const q1 = await client.query('r29q5', { hello: 'world' });
 
-  if ('data' in q1) {
-    console.log('data.input', q1.data.input);
+  if ('error' in q1) {
+    console.log(q1);
+  } else {
+    console.log(q1);
   }
 }
 

--- a/scripts/generate-big-f-router.ts
+++ b/scripts/generate-big-f-router.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 const NUM_ROUTERS = 100;
-const NUM_PROCEDURES_PER_ROUTER = 10;
+const NUM_PROCEDURES_PER_ROUTER = 30;
 
 const WRAPPER = `
 import { trpc } from '../context';
@@ -46,9 +46,7 @@ for (let routerIndex = 0; routerIndex < NUM_ROUTERS; routerIndex++) {
     ),
     (params) => {
       return {
-        data: {
-          input: params.input,
-        }
+        input: params.input,
       }
     }
   ),

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -8,7 +8,7 @@ async function main() {
   {
     // query 'whoami'
     const result = await appRouter.queries['viewer.whoami']({ ctx: {} });
-    if ('error' in result) {
+    if (typeof result === 'object' && 'error' in result) {
       expectTypeOf<typeof result['error']>().toMatchTypeOf<
         | {
             code: 'UNAUTHORIZED';
@@ -61,9 +61,7 @@ async function main() {
     trpc.router({
       queries: {
         test: () => {
-          return {
-            data: 'ok',
-          };
+          return 'ok';
         },
       },
       // @ts-expect-error should error

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -31,10 +31,8 @@ async function main() {
         // zod error inferred - useful for forms w/o libs
         console.log(result.error.zod.hello?._errors);
       }
-    } else if ('data' in result) {
-      console.log(result.data);
     } else {
-      throw new Error("Procedure didn't return data");
+      console.log(result);
     }
 
     // some type testing below
@@ -45,9 +43,7 @@ async function main() {
     }>();
 
     expectTypeOf<MyProcedure['data']>().toMatchTypeOf<{
-      data: {
-        greeting: string;
-      };
+      greeting: string;
     }>();
 
     expectTypeOf<MyProcedure['_input_in']>().toMatchTypeOf<{

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,10 +38,14 @@ export const appRouter = trpc.router({
   queries: {
     // simple procedure without args avialable at `post.all`
     'post.all': (_params) => {
+      return postsDb;
+    },
+    // simple procedure without args avialable at `post.all`
+    'post.byId': trpc.resolver(() => {
       return {
         data: postsDb,
       };
-    },
+    }),
     // procedure with input validation called `greeting`
     greeting: trpc.resolver(
       trpc.zod(
@@ -66,7 +70,7 @@ export const appRouter = trpc.router({
       isAuthed(),
       ({ ctx }) => {
         // `ctx.user` is now `NonNullable`
-        return { data: `your id is ${ctx.user.id}` };
+        return `your id is ${ctx.user.id}`;
       },
     ),
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,11 +11,9 @@ const trpc = initTRPC<Context>();
 
 const isAuthed = trpc.newContext((params) => {
   if (!params.ctx.user) {
-    return {
-      error: {
-        code: 'UNAUTHORIZED',
-      },
-    };
+    return trpc.error({
+      code: 'UNAUTHORIZED',
+    });
   }
   return {
     ctx: {
@@ -58,9 +56,7 @@ export const appRouter = trpc.router({
       ),
       (params) => {
         return {
-          data: {
-            greeting: 'hello ' + params.ctx.user?.id ?? params.input.hello,
-          },
+          greeting: 'hello ' + params.ctx.user?.id ?? params.input.hello,
         };
       },
     ),

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,12 +40,23 @@ export const appRouter = trpc.router({
     'post.all': (_params) => {
       return postsDb;
     },
-    // simple procedure without args avialable at `post.all`
-    'post.byId': trpc.resolver(() => {
-      return {
-        data: postsDb,
-      };
-    }),
+    // get post by id or 404 if it's not found
+    'post.byId': trpc.resolver(
+      trpc.zod(
+        z.object({
+          id: z.string(),
+        }),
+      ),
+      ({ input }) => {
+        const post = postsDb.find((post) => post.id === input.id);
+        if (!post) {
+          return trpc.error({ code: 'NOT_FOUND' });
+        }
+        return {
+          data: postsDb,
+        };
+      },
+    ),
     // procedure with input validation called `greeting`
     greeting: trpc.resolver(
       trpc.zod(

--- a/src/trpc/server/initTRPC.ts
+++ b/src/trpc/server/initTRPC.ts
@@ -3,6 +3,7 @@ import {
   createNewContext,
   pipedResolver,
   zod,
+  error,
 } from '.';
 
 export function initTRPC<TContext>() {
@@ -23,5 +24,6 @@ export function initTRPC<TContext>() {
      * Zod middlware
      */
     zod,
+    error,
   };
 }

--- a/src/trpc/server/middlewares/newContext.ts
+++ b/src/trpc/server/middlewares/newContext.ts
@@ -5,15 +5,14 @@ import {
   ProcedureResultError,
 } from '..';
 
-type IsProcedureResultErrorLike<T> = T extends ProcedureResultError ? T : never;
+type IsProcedureResultErrorLike<T> = T extends ProcedureResultError<any>
+  ? T
+  : never;
 /**
  * Utility for creating a middleware that swaps the context around
  */
 export function createNewContext<TInputContext>() {
-  return function newContextFactory<
-    TNewContext,
-    TError extends ProcedureResultError,
-  >(
+  return function newContextFactory<TNewContext, TError>(
     newContextCallback: (
       params: Params<TInputContext>,
     ) => MaybePromise<

--- a/src/trpc/server/middlewares/zod.ts
+++ b/src/trpc/server/middlewares/zod.ts
@@ -1,5 +1,10 @@
 import type { z } from 'zod';
-import { InputSchema, MiddlewareFunction } from '..';
+import {
+  error,
+  InputSchema,
+  MiddlewareFunction,
+  ProcedureResultError,
+} from '..';
 
 /***
  * Utility for creating a zod middleware
@@ -9,7 +14,10 @@ export function zod<TInputParams, TSchema extends z.ZodTypeAny>(
 ): MiddlewareFunction<
   TInputParams,
   TInputParams & InputSchema<z.input<TSchema>, z.output<TSchema>>,
-  { error: { code: 'BAD_REQUEST'; zod: z.ZodFormattedError<z.input<TSchema>> } }
+  ProcedureResultError<{
+    code: 'BAD_REQUEST';
+    zod: z.ZodFormattedError<z.input<TSchema>>;
+  }>
 > {
   type zInput = z.input<TSchema>;
   type zOutput = z.output<TSchema>;
@@ -28,11 +36,10 @@ export function zod<TInputParams, TSchema extends z.ZodTypeAny>(
     }
 
     const zod = (result as z.SafeParseError<zInput>).error.format();
-    return {
-      error: {
-        code: 'BAD_REQUEST',
-        zod,
-      },
-    };
+    const err = error({
+      code: 'BAD_REQUEST',
+      zod,
+    });
+    return err;
   };
 }

--- a/src/trpc/server/router.ts
+++ b/src/trpc/server/router.ts
@@ -1,8 +1,8 @@
-import { Procedure, ProcedureResult } from './';
+import { Procedure } from './';
 
 type ProcedureRecord<TContext> = Record<
   string,
-  Procedure<{ ctx: TContext }, ProcedureResult>
+  Procedure<{ ctx: TContext }, any>
 >;
 
 export interface ProceduresByType<TContext> {

--- a/src/trpc/server/types.ts
+++ b/src/trpc/server/types.ts
@@ -3,13 +3,21 @@ import { ProcedureResultError, Procedure, ProcedureWithMeta } from './';
 ///////////// inference helpers //////////
 type ExcludeErrorLike<T> = T extends ProcedureResultError<any> ? never : T;
 type OnlyErrorLike<T> = T extends ProcedureResultError<any> ? T : never;
+export interface ClientError<T extends ProcedureResultError<any>> {
+  error: T['error'];
+}
+type OmitErrorResultMarkersFromResult<T> = T extends ProcedureResultError<any>
+  ? ClientError<T>
+  : T;
+
 export interface ProcedureDefinition<TContext, TInputIn, TInputOut, TResult>
   extends InputSchema<TInputIn, TInputOut> {
   ctx: TContext;
-  result: TResult;
+  result: OmitErrorResultMarkersFromResult<TResult>;
   data: ExcludeErrorLike<TResult>;
-  errors: OnlyErrorLike<TResult>;
+  errors: ClientError<OnlyErrorLike<TResult>>;
 }
+
 type inferParamsInput<TParams> = TParams extends InputSchema<
   infer TBefore,
   infer TAfter

--- a/src/trpc/server/types.ts
+++ b/src/trpc/server/types.ts
@@ -23,9 +23,7 @@ type inferProcedureParams<TProcedure extends Procedure<any, any>> =
     ? TParams
     : never;
 type inferProcedureResult<TProcedure extends Procedure<any, any>> =
-  TProcedure extends Procedure<any, infer TResult>
-    ? ExcludeErrorLike<TResult>
-    : never;
+  TProcedure extends Procedure<any, infer TResult> ? TResult : never;
 export type inferProcedure<TProcedure extends Procedure<any, any>> =
   ProcedureDefinition<
     inferProcedureParams<TProcedure>['ctx'],

--- a/src/trpc/server/types.ts
+++ b/src/trpc/server/types.ts
@@ -1,8 +1,8 @@
 import { ProcedureResultError, Procedure, ProcedureWithMeta } from './';
 
 ///////////// inference helpers //////////
-type ExcludeErrorLike<T> = T extends ProcedureResultError ? never : T;
-type OnlyErrorLike<T> = T extends ProcedureResultError ? T : never;
+type ExcludeErrorLike<T> = T extends ProcedureResultError<any> ? never : T;
+type OnlyErrorLike<T> = T extends ProcedureResultError<any> ? T : never;
 export interface ProcedureDefinition<TContext, TInputIn, TInputOut, TResult>
   extends InputSchema<TInputIn, TInputOut> {
   ctx: TContext;
@@ -23,7 +23,9 @@ type inferProcedureParams<TProcedure extends Procedure<any, any>> =
     ? TParams
     : never;
 type inferProcedureResult<TProcedure extends Procedure<any, any>> =
-  TProcedure extends Procedure<any, infer TResult> ? TResult : never;
+  TProcedure extends Procedure<any, infer TResult>
+    ? ExcludeErrorLike<TResult>
+    : never;
 export type inferProcedure<TProcedure extends Procedure<any, any>> =
   ProcedureDefinition<
     inferProcedureParams<TProcedure>['ctx'],


### PR DESCRIPTION
Instead of having all procedures to return a `{ data: X } | { error: Y }` shape, use an `error({ code: 'X ', /* additional data */})`


### Questions

- Should it really be called `error()` - maybe an `invalid()`/`bad()`-helper would be more suitable
  - It's not an `Error`, it's more about signalling a bad request - proper thrown errors will be handled in a similar fashion of what they are today.

### Benefits
- Less typing for happy paths
- More explicit error handling
- When returning `undefined`, which is common for mutations, you don't have to `return` anything in the fn

### Example use

```ts
export const appRouter = trpc.router({
  queries: {
    'post.byId': trpc.resolver(
      trpc.zod(
        z.object({
          id: z.string(),
        }),
      ),
      ({ input }) => {
        const post = postsDb.find((post) => post.id === input.id);
        if (!post) {
          return trpc.error({ code: 'NOT_FOUND' });
        }
        return post;
      },
    ),
});
```

#### The result of the above is:

```ts
type Result =
  | Post
  | {
      error: {
        code: 'BAD_REQUEST';
        zod: z.ZodFormattedError<{
          id: string;
        }>;
      };
    }
  | {
      error: {
        code: 'NOT_FOUND';
      };
    };
```

### Details

- The error fn adds a `Symbol` that is easily identifiable both in code and in generics


---

Suggestion by @mmkal