### PR TITLE
POCs for function-like hooks

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,11 +1,16 @@
 import type { appRouter } from './server';
-import { createClient, createBetterClient } from './trpc/client';
+import {
+  createClient,
+  createProxyClient,
+  createFlatClient,
+} from './trpc/client';
 import { createRouterProxy } from './trpc/client/createRouterProxy';
 
 const client = createClient<typeof appRouter>();
-const betterClient = createBetterClient<typeof appRouter>();
+const proxyClient = createProxyClient<typeof appRouter>();
+const flatClient = createFlatClient<typeof appRouter>();
 
-betterClient.post.some();
+proxyClient.post.some();
 
 const { queries } = createRouterProxy<typeof appRouter>();
 
@@ -28,11 +33,20 @@ async function main() {
     console.log({ greeting, posts });
   }
 
-  // full dot-notation RPC
-  // no "Go to definition
+  // nested function-call API
+  // "Go to definition" doesn't work
   {
-    const greeting = await betterClient.greeting({ hello: 'string' });
-    const posts = await betterClient.post.all();
+    const greeting = await proxyClient.greeting({ hello: 'string' });
+    const posts = await proxyClient.post.all();
+    console.log({ greeting, posts });
+  }
+
+  // "flat" function-call API
+  // "Go to definition" does work
+  // users who dislike the square brackets should avoid nested routers 🤷‍♂️
+  {
+    const greeting = await flatClient.greeting({ hello: 'string' });
+    const posts = await flatClient['post.all']();
     console.log({ greeting, posts });
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,12 @@
 import type { appRouter } from './server';
-import { createClient } from './trpc/client';
+import { createClient, createBetterClient } from './trpc/client';
 import { createRouterProxy } from './trpc/client/createRouterProxy';
 
 const client = createClient<typeof appRouter>();
+const betterClient = createBetterClient<typeof appRouter>();
+
+betterClient.post.some();
+
 const { queries } = createRouterProxy<typeof appRouter>();
 
 async function main() {
@@ -21,6 +25,14 @@ async function main() {
     const greeting = await client.query('greeting', { hello: 'string' });
     const posts = await client.query('post.all');
 
+    console.log({ greeting, posts });
+  }
+
+  // full dot-notation RPC
+  // no "Go to definition
+  {
+    const greeting = await betterClient.greeting({ hello: 'string' });
+    const posts = await betterClient.post.all();
     console.log({ greeting, posts });
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,16 +1,14 @@
 import type { appRouter } from './server';
 import {
   createClient,
-  createProxyClient,
+  createNestedClient,
   createFlatClient,
 } from './trpc/client';
 import { createRouterProxy } from './trpc/client/createRouterProxy';
 
 const client = createClient<typeof appRouter>();
-const proxyClient = createProxyClient<typeof appRouter>();
+const nestedClient = createNestedClient<typeof appRouter>();
 const flatClient = createFlatClient<typeof appRouter>();
-
-proxyClient.post.some();
 
 const { queries } = createRouterProxy<typeof appRouter>();
 
@@ -36,8 +34,8 @@ async function main() {
   // nested function-call API
   // "Go to definition" doesn't work
   {
-    const greeting = await proxyClient.greeting({ hello: 'string' });
-    const posts = await proxyClient.post.all();
+    const greeting = await nestedClient.query.greeting({ hello: 'string' });
+    const posts = await nestedClient.query.post.all();
     console.log({ greeting, posts });
   }
 
@@ -45,8 +43,8 @@ async function main() {
   // "Go to definition" does work
   // users who dislike the square brackets should avoid nested routers 🤷‍♂️
   {
-    const greeting = await flatClient.greeting({ hello: 'string' });
-    const posts = await flatClient['post.all']();
+    const greeting = await flatClient.query.greeting({ hello: 'string' });
+    const posts = await flatClient.query['post.all']();
     console.log({ greeting, posts });
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,11 @@ export const appRouter = trpc.router({
         data: postsDb,
       };
     },
+    ['post.some']: (_params) => {
+      return {
+        data: postsDb,
+      };
+    },
     // procedure with input validation called `greeting`
     greeting: trpc.resolver(
       trpc.zod(

--- a/src/trpc/client/client.ts
+++ b/src/trpc/client/client.ts
@@ -71,13 +71,22 @@ type betterRoute<
 > = Key extends `${infer A}.${infer B}`
   ? { [k in A]: betterRoute<B, FullKey, Procs> }
   : { [k in Key]: procToHook<Procs, FullKey> };
-type betterClient<TProcs extends ProcedureRecord<any>> = unionToIntersection<
+type proxyClient<TProcs extends ProcedureRecord<any>> = unionToIntersection<
   keyof TProcs extends string
     ? betterRoute<keyof TProcs, keyof TProcs, TProcs>
     : unknown
 >;
-export function createBetterClient<
+export function createProxyClient<
   TRouter extends ProceduresByType<any>,
->(): betterClient<noUndefined<TRouter['queries']>> {
+>(): proxyClient<noUndefined<TRouter['queries']>> {
+  return 'asdf' as any;
+}
+
+type flatClient<TProcs extends ProcedureRecord<any>> = {
+  [k in keyof TProcs]: procToHook<TProcs, k>;
+};
+export function createFlatClient<
+  TRouter extends ProceduresByType<any>,
+>(): flatClient<noUndefined<TRouter['queries']>> {
   return 'asdf' as any;
 }

--- a/src/trpc/client/client.ts
+++ b/src/trpc/client/client.ts
@@ -71,22 +71,22 @@ type betterRoute<
 > = Key extends `${infer A}.${infer B}`
   ? { [k in A]: betterRoute<B, FullKey, Procs> }
   : { [k in Key]: procToHook<Procs, FullKey> };
-type proxyClient<TProcs extends ProcedureRecord<any>> = unionToIntersection<
+type nestedClient<TProcs extends ProcedureRecord<any>> = unionToIntersection<
   keyof TProcs extends string
     ? betterRoute<keyof TProcs, keyof TProcs, TProcs>
     : unknown
 >;
-export function createProxyClient<
-  TRouter extends ProceduresByType<any>,
->(): proxyClient<noUndefined<TRouter['queries']>> {
+export function createNestedClient<TRouter extends ProceduresByType<any>>(): {
+  query: nestedClient<noUndefined<TRouter['queries']>>;
+} {
   return 'asdf' as any;
 }
 
 type flatClient<TProcs extends ProcedureRecord<any>> = {
   [k in keyof TProcs]: procToHook<TProcs, k>;
 };
-export function createFlatClient<
-  TRouter extends ProceduresByType<any>,
->(): flatClient<noUndefined<TRouter['queries']>> {
+export function createFlatClient<TRouter extends ProceduresByType<any>>(): {
+  query: flatClient<noUndefined<TRouter['queries']>>;
+} {
   return 'asdf' as any;
 }

--- a/src/trpc/server/router.ts
+++ b/src/trpc/server/router.ts
@@ -1,6 +1,6 @@
 import { Procedure, ProcedureResult } from './';
 
-type ProcedureRecord<TContext> = Record<
+export type ProcedureRecord<TContext> = Record<
   string,
   Procedure<{ ctx: TContext }, ProcedureResult>
 >;


### PR DESCRIPTION
Not a real PR, just proofs of concept. Two proposed APIs. Both require Proxy.

## Flat "function-call" API
- Pro: "Go to definition" **does** work
- Con: looks weird for procedures with dots in the name

```ts
const flatClient = createFlatClient<typeof appRouter>();
const greeting = await flatClient.query.greeting({ hello: 'string' });
const posts = await flatClient.query['post.all']();
```

## Nested "function-call" API
- Pro: it's pretty
- Con: breaks "Go to definition"

```ts
const nestedClient = createNestedClient<typeof appRouter>();
const greeting = await nestedClient.query.greeting({ hello: 'string' });
const posts = await nestedClient.query.post.all();
```

I prefer the nested version personally. Since both of these require Proxy you might as well try to maintain the "feel"/illusion of a router hierarchy. 

#### Router merging

If you go with the nested version, I think the router merging API should add periods under the hood, instead of doing a simple concatenation. Since the nested client API treats the period as a special character, it shouldn't be the job of the developer to include it. Rather, using periods in procedure names should be discouraged/disallowed. It's also just looks cleaner.

```ts
// server
const postRouter = trpc.router()
  .query('fetch', {
    resolve(params){ return []; }
  });

const appRouter = trpc.router()
  .merge('post', postRouter) // "post" not "post."


// client
client.query.post.fetch()
```

You could make this a non-breaking change by implementing this new behavior as a new method. Some options:

```ts
trpc.router().subrouter('post', postRouter)
trpc.router().compose('post', postRouter)
trpc.router().use('post', postRouter)
```